### PR TITLE
bump to use v1.10.16-statediff-3.0.2

### DIFF
--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
-  version = "0.30.0-v1.10.14-statediff-0.0.29";
+  version = "0.30.0-v1.10.16-statediff-3.0.2";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper shellcheck coreutils nodejs];

--- a/src/dapp/libexec/dapp/dapp---version
+++ b/src/dapp/libexec/dapp/dapp---version
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-echo dapp 0.30.0-v1.10.14-statediff-0.0.29
+echo dapp 0.30.0-v1.10.16-statediff-3.0.2
 # use a custom path is DAPP_SOLC is set
 SOLC=${DAPP_SOLC:-solc}
 $SOLC --version

--- a/src/go-ethereum-statediff/default.nix
+++ b/src/go-ethereum-statediff/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "go-ethereum-statediff";
-  version = "v1.10.14-statediff-0.0.29";
+  version = "v1.10.16-statediff-3.0.2";
   src = fetchurl {
     url = "https://github.com/vulcanize/go-ethereum/releases/download/${version}/geth-linux-amd64";
-    sha256 = "0s1brrr7c36y0pap1f4vll07n2lvjc90yxa6rhx5g6jpsivmfci5";
+    sha256 = "0c488ns6w6jzcwwvw3p29i3n7yyp7ji8qy91133cwy4v37zl5lnk";
   };
 
   phases = ["installPhase" "patchPhase"];


### PR DESCRIPTION
And since it doesn't seem to be well documented, the way to generate the sha256 hash for default.nix is 

`nix-prefetch-url https://github.com/vulcanize/go-ethereum/releases/download/v1.10.16-statediff-3.0.2/geth-linux-amd64`